### PR TITLE
allow showing tips as messages

### DIFF
--- a/autoload/fortune_vimtips.vim
+++ b/autoload/fortune_vimtips.vim
@@ -5,7 +5,7 @@ let s:fortunecount = count(s:fortunes, "%") + 1
 let s:fortunestr = join(s:fortunes, "\n")
 let s:fortunes = split(s:fortunestr, "\n%\n")
 
-function! fortune_vimtips#viewtips()
+function! fortune_vimtips#show_in_window(tip) abort
     " Add a map to close more easy the window
     silent! nmap <unique> <silent> <Leader>o :only<CR>
 
@@ -25,11 +25,21 @@ function! fortune_vimtips#viewtips()
         silent exec win_nr . "wincmd w"
     endif
 
-    silent exec append(0, 'Did you know ?')
-    silent exec append(1, split(get(s:fortunes, GetFortune()), "\n"))
+    silent call append(0, a:tip)
     call cursor(1,1)
 
     silent exec win_restore . "wincmd w"
+endfunction
+
+function! fortune_vimtips#viewtips()
+    let tip = split(get(s:fortunes, GetFortune()), "\n")
+    call insert(tip, 'Did you know?', 0)
+
+    if g:fortune_display_in_window
+        call fortune_vimtips#show_in_window(tip)
+    else
+        echomsg join(tip, ' ')
+    endif
 endfunction
 
 function! fortune_vimtips#tooltipviewtips()

--- a/autoload/fortune_vimtips.vim
+++ b/autoload/fortune_vimtips.vim
@@ -35,7 +35,7 @@ function! fortune_vimtips#viewtips()
     let tip = split(get(s:fortunes, GetFortune()), "\n")
     call insert(tip, 'Did you know?', 0)
 
-    if g:fortune_display_in_window
+    if g:fortune_vimtips_display_in_window
         call fortune_vimtips#show_in_window(tip)
     else
         echomsg join(tip, ' ')

--- a/doc/fortune_vimtips.txt
+++ b/doc/fortune_vimtips.txt
@@ -37,6 +37,12 @@ Overview:
         fortunes subdirectory of the plugin.
 
                                               *g:fortune_vimtips_display_in_tooltip*
+    |g:fortune_vimtips_display_in_window|      boolean ( default 1 )
+
+        Use this option to display the tip in a separate window.
+        If this option is 0 then tip will be echoed as message on start.
+
+                                              *g:fortune_vimtips_display_in_tooltip*
     |g:fortune_vimtips_display_in_tooltip|      boolean ( default 0 )
 
         Use this option to display the tip on a gvim tooltip.

--- a/doc/fortune_vimtips.txt
+++ b/doc/fortune_vimtips.txt
@@ -36,7 +36,7 @@ Overview:
         (fortunes separated by lines containing a % character only) in the
         fortunes subdirectory of the plugin.
 
-                                              *g:fortune_vimtips_display_in_tooltip*
+                                              *g:fortune_vimtips_display_in_window*
     |g:fortune_vimtips_display_in_window|      boolean ( default 1 )
 
         Use this option to display the tip in a separate window.

--- a/plugin/fortune_vimtips.vim
+++ b/plugin/fortune_vimtips.vim
@@ -21,8 +21,8 @@ if !exists('g:fortune_vimtips_display_in_tooltip')
     let g:fortune_vimtips_display_in_tooltip = 0
 endif
 
-if !exists('g:fortune_display_in_window')
-  let g:fortune_display_in_window = 1
+if !exists('g:fortune_vimtips_display_in_window')
+  let g:fortune_vimtips_display_in_window = 1
 endif
 
 if &diff == 0 && g:fortune_vimtips_auto_display && !has("gui_running")

--- a/plugin/fortune_vimtips.vim
+++ b/plugin/fortune_vimtips.vim
@@ -21,6 +21,10 @@ if !exists('g:fortune_vimtips_display_in_tooltip')
     let g:fortune_vimtips_display_in_tooltip = 0
 endif
 
+if !exists('g:fortune_display_in_window')
+  let g:fortune_display_in_window = 1
+endif
+
 if &diff == 0 && g:fortune_vimtips_auto_display && !has("gui_running")
     au VIMEnter * call fortune_vimtips#viewtips()
 endif


### PR DESCRIPTION
Thank you for a very intersting plugin! Everything is fine, but I found window-based tip display to be a bit confusing, I think it it would be more natural to display them as messages.

In this commit I've added a new option: `g:fortune_display_in_window` which is `1` by default (current behavior), but if you set it to `0` then tips will be displayed as messages. 